### PR TITLE
Tokenize the `space` value when stringify-ing

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ See the accompanying LICENSE file for terms.
 var isRegExp = require('util').isRegExp;
 
 // Generate an internal UID to make the regexp pattern harder to guess.
-var UID                 = Math.floor(Math.random() * 0x10000000000).toString(16);
+var UID                 = Math.floor(Math.random() * 0x10000000000).toString(36);
 var PLACE_HOLDER_REGEXP = new RegExp('"@__(FUNCTION|REGEXP)-' + UID + '-(\\d+)__@"', 'g');
 
 var IS_NATIVE_CODE_REGEXP = /\{\s*\[native code\]\s*\}/g;
@@ -29,8 +29,10 @@ var UNICODE_CHARS = {
 // and the subsequent `str.replace()` call to take over 100x more time than when
 // a the `JSON.stringify()` replacer function is used and the data being
 // serialized is very large (500KB). A remedy to this is setting the
-// `JSON.stringify()` `space` option to a truthy value.
-var SPACE = 2;
+// `JSON.stringify()` `space` option to a truthy value which is a token that is
+// later removed to keep the file size down.
+var SPACE        = '@' + UID + '@';
+var SPACE_REGPEX = new RegExp('\\n(@' + UID + '@)+', 'g');
 
 module.exports = function serialize(obj) {
     var functions = [];
@@ -57,6 +59,8 @@ module.exports = function serialize(obj) {
     if (typeof str !== 'string') {
         return String(str);
     }
+
+    str = str.replace(SPACE_REGPEX, '');
 
     // Replace unsafe HTML and invalid JavaScript line terminator chars with
     // their safe Unicode char counterpart. This _must_ happen before the

--- a/index.js
+++ b/index.js
@@ -32,7 +32,7 @@ var UNICODE_CHARS = {
 // `JSON.stringify()` `space` option to a truthy value which is a token that is
 // later removed to keep the file size down.
 var SPACE        = '@' + UID + '@';
-var SPACE_REGPEX = new RegExp('\\n(@' + UID + '@)+', 'g');
+var SPACE_REGEXP = new RegExp('\\n(@' + UID + '@)+', 'g');
 
 module.exports = function serialize(obj) {
     var functions = [];
@@ -60,7 +60,7 @@ module.exports = function serialize(obj) {
         return String(str);
     }
 
-    str = str.replace(SPACE_REGPEX, '');
+    str = str.replace(SPACE_REGEXP, '');
 
     // Replace unsafe HTML and invalid JavaScript line terminator chars with
     // their safe Unicode char counterpart. This _must_ happen before the

--- a/test/unit/serialize.js
+++ b/test/unit/serialize.js
@@ -46,7 +46,11 @@ describe('serialize( obj )', function () {
         });
 
         it('should serialize JSON to a JSON string', function () {
-            expect(serialize(data)).to.equal(JSON.stringify(data, null, 2));
+            var serialized  = serialize(data);
+            var stringified = JSON.stringify(data);
+
+            expect(serialized).to.be.a('string');
+            expect(JSON.parse(serialized)).to.deep.equal(JSON.parse(stringified));
         });
 
         it('should deserialize a JSON string to a JSON object', function () {


### PR DESCRIPTION
Using a token for the `space` value, the Node 0.10 CPU issue is avoid while also keeping the file size closer to the no-space size.

Using the test script in #3, the results of this method add a bit of CPU time, but its worth the reduction in size:

**1 space:**
```
[48885]      803 ms: Scavenge 109.4 (142.2) -> 106.3 (142.2) MB, 0 ms [Runtime::PerformGC].
memory usage: { rss: 140365824, heapTotal: 127084240, heapUsed: 117960976 }
memory usage: { rss: 140394496, heapTotal: 127084240, heapUsed: 118006704 }
str.replace takes 4 ms.
```

**Tokenized space:**
```
[48879]      880 ms: Mark-sweep 156.3 (190.6) -> 107.8 (148.2) MB, 41 ms [allocation failure] [GC in old space requested].
memory usage: { rss: 151355392, heapTotal: 160808928, heapUsed: 120760240 }
memory usage: { rss: 151359488, heapTotal: 160808928, heapUsed: 120818752 }
str.replace takes 2 ms.
```

/cc @redonkulus @kaesonho 