### PR TITLE
Support dates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Serialize JavaScript
 ====================
 
-Serialize JavaScript to a _superset_ of JSON that includes regular expressions and functions.
+Serialize JavaScript to a _superset_ of JSON that includes regular expressions, dates and functions.
 
 [![npm Version][npm-badge]][npm]
 [![Dependency Status][david-badge]][david]
@@ -11,7 +11,7 @@ Serialize JavaScript to a _superset_ of JSON that includes regular expressions a
 
 The code in this package began its life as an internal module to [express-state][]. To expand its usefulness, it now lives as `serialize-javascript` — an independent package on npm.
 
-You're probably wondering: **What about `JSON.stringify()`!?** We've found that sometimes we need to serialize JavaScript **functions** and **regexps**. A great example is a web app that uses client-side URL routing where the route definitions are regexps that need to be shared from the server to the client.
+You're probably wondering: **What about `JSON.stringify()`!?** We've found that sometimes we need to serialize JavaScript **functions**, **regexps** or **dates**. A great example is a web app that uses client-side URL routing where the route definitions are regexps that need to be shared from the server to the client.
 
 The string returned from this package's single export function is literal JavaScript which can be saved to a `.js` file, or be embedded into an HTML document by making the content of a `<script>` element. **HTML charaters and JavaScript line terminators are escaped automatically.**
 
@@ -36,6 +36,7 @@ serialize({
     bool : true,
     nil  : null,
     undef: undefined,
+    date: new Date("Thu, 28 Apr 2016 22:02:17 GMT"),
 
     fn: function echo(arg) { return arg; },
     re: /([^\s]+)/g
@@ -45,7 +46,7 @@ serialize({
 The above will produce the following string output:
 
 ```js
-'{"str":"string","num":0,"obj":{"foo":"foo"},"arr":[1,2,3],"bool":true,"nil":null,"fn":function echo(arg) { return arg; },"re":/([^\\s]+)/g}'
+'{"str":"string","num":0,"obj":{"foo":"foo"},"arr":[1,2,3],"bool":true,"nil":null,date:new Date("2016-04-28T22:02:17.156Z"),"fn":function echo(arg) { return arg; },"re":/([^\\s]+)/g}'
 ```
 
 Note: to produced a beautified string, you can pass an optional second argument to `serialize()` to define the number of spaces to be used for the indentation.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "serialize-javascript",
   "version": "1.2.0",
-  "description": "Serialize JavaScript to a superset of JSON that includes regular expressions and functions.",
+  "description": "Serialize JavaScript to a superset of JSON that includes regular expressions, dates and functions.",
   "main": "index.js",
   "scripts": {
     "benchmark": "node test/benchmark/serialize.js",

--- a/test/unit/serialize.js
+++ b/test/unit/serialize.js
@@ -169,4 +169,23 @@ describe('serialize( obj )', function () {
             expect(eval(serialize('</script>'))).to.equal('</script>');
         });
     });
+
+    describe('dates', function () {
+        it('should serialize dates', function () {
+            var d = new Date('2016-04-28T22:02:17.156Z');
+            expect(serialize(d)).to.be.a('string').equal('new Date("2016-04-28T22:02:17.156Z")');
+        });
+
+        it('should deserialize a date', function () {
+            var d = eval(serialize(new Date('2016-04-28T22:02:17.156Z')));
+            expect(d).to.be.a('Date');
+            expect(d.toISOString()).to.equal('2016-04-28T22:02:17.156Z');
+        });
+
+        it('should deserialize a string that is not a valid date', function () {
+            var d = eval(serialize('2016-04-28T25:02:17.156Z'));
+            expect(d).to.be.a('string');
+            expect(d).to.equal('2016-04-28T25:02:17.156Z');
+        });
+    })
 });


### PR DESCRIPTION
Closes #15 

There is a little trick to test if a value is a date because `Date.prototype.toJSON` is used before we can access the value in the stringify replacement function, so we end up with a `date.toISOString()` result.
