### PR TITLE
Don't replace escaped regex / function placeholders in strings

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,5 +30,8 @@
     "istanbul": "^0.3.2",
     "mocha": "^1.21.4",
     "xunit-file": "0.0.5"
+  },
+  "dependencies": {
+    "randombytes": "^2.0.3"
   }
 }

--- a/test/unit/serialize.js
+++ b/test/unit/serialize.js
@@ -1,8 +1,22 @@
 /* global describe, it, beforeEach */
 'use strict';
 
+// temporarily monkeypatch `crypto.randomBytes` so we'll have a
+// predictable UID for our tests
+var crypto = require('crypto');
+var oldRandom = crypto.randomBytes;
+crypto.randomBytes = function(len, cb) {
+    var buf = new Buffer(len);
+    buf.fill(0x00);
+    if (cb)
+        cb(null, buf);
+    return buf;
+};
+
 var serialize = require('../../'),
     expect    = require('chai').expect;
+
+crypto.randomBytes = oldRandom;
 
 describe('serialize( obj )', function () {
     it('should be a function', function () {
@@ -108,6 +122,18 @@ describe('serialize( obj )', function () {
             expect(Number.toString()).to.equal('function Number() { [native code] }');
             try { serialize(Number); } catch (e) { err = e; }
             expect(err).to.be.an.instanceOf(TypeError);
+        });
+    });
+
+    describe('placeholders', function() {
+        it('should not be replaced within string literals', function () {
+            // Since we made the UID deterministic this should always be the placeholder
+            var fakePlaceholder = '"@__R-0000000000000000-0__@';
+            var serialized = serialize({bar: /1/i, foo: fakePlaceholder}, {uid: 'foo'});
+            var obj = eval('(' + serialized + ')');
+            expect(obj).to.be.a('Object');
+            expect(obj.foo).to.be.a('String');
+            expect(obj.foo).to.equal(fakePlaceholder);
         });
     });
 


### PR DESCRIPTION
Previously we weren't checking if the quote that started the placeholder
was escaped or not, meaning an object like

``` js
{"foo": /1"/, "bar": "a\"@__R-<UID>-0__@"}
```

Would be serialized as

``` js
{"foo": /1"/, "bar": "a\/1"/}
```

meaning an attacker could escape out of `bar` if they controlled both
`foo` and `bar` and were able to guess the value of `<UID>`.

`UID` is generated once on startup, is chosen using `Math.random()` and
has a keyspace of roughly 4 billion, so within the realm of an online
attack.

Here's a simple example that will cause `console.log()` to be called when
the `serialize()`d version is `eval()`d

``` js
eval('('+ serialize({"foo": /1" + console.log(1)/i, "bar": '"@__R-<UID>-0__@'}) + ')');
```

Where `<UID>` is the guessed `UID`.

This fixes the issue by ensuring that placeholders are not preceded by
a backslash.
