### PR TITLE
README: Replace deserialize eval with JSON.parse

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,15 +104,7 @@ serialize(obj, {unsafe: true});
 
 ## Deserializing
 
-For some use cases you might also need to deserialize the string. This is explicitly not part of this module. However, you can easily write it yourself:
-
-```js
-function deserialize(serializedJavascript){
-  return eval('(' + serializedJavascript + ')');
-}
-```
-
-**Note:** Don't forget the parentheses around the serialized javascript, as the opening bracket `{` will be considered to be the start of a body.
+For some use cases you might also need to deserialize the string. Modern browsers support using [JSON.parse](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/parse) to deserialize JSON, which protects against malicious scripts being executed through malformed JSON.
 
 ## License
 


### PR DESCRIPTION
From json.org:

> The eval function is very fast. However, it can compile and execute any JavaScript program, so there can be security issues. The use of eval is indicated when the source is trusted and competent. It is much safer to use a JSON parser. In web applications over XMLHttpRequest, communication is permitted only to the same origin that provide that page, so it is trusted. But it might not be competent. If the server is not rigorous in its JSON encoding, or if it does not scrupulously validate all of its inputs, then it could deliver invalid JSON text that could be carrying dangerous script. The eval function would execute the script, unleashing its malice.

This updates README.md to suggest using [JSON.parse](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/parse) instead.