### PR TITLE
Enhanced object literals support

### DIFF
--- a/test/unit/serialize.js
+++ b/test/unit/serialize.js
@@ -112,10 +112,11 @@ describe('serialize( obj )', function () {
 
         it('should serialize enhanced literal objects', function () {
             var obj = {
-                hello() { return true; }
+                foo() { return true; },
+                *bar() { return true; }
             };
 
-            expect(serialize(obj)).to.equal('{"hello":function() { return true; }}');
+            expect(serialize(obj)).to.equal('{"foo":function() { return true; },"bar":function*() { return true; }}');
         });
 
         it('should deserialize enhanced literal objects', function () {

--- a/test/unit/serialize.js
+++ b/test/unit/serialize.js
@@ -109,6 +109,21 @@ describe('serialize( obj )', function () {
             try { serialize(Number); } catch (e) { err = e; }
             expect(err).to.be.an.instanceOf(TypeError);
         });
+
+        it('should serialize enhanced literal objects', function () {
+            var obj = {
+                hello() { return true; }
+            };
+
+            expect(serialize(obj)).to.equal('{"hello":function() { return true; }}');
+        });
+
+        it('should deserialize enhanced literal objects', function () {
+            var obj;
+            eval('obj = ' + serialize({ hello() { return true; } }));
+
+            expect(obj.hello()).to.equal(true);
+        });
     });
 
     describe('regexps', function () {


### PR DESCRIPTION
Unfortunately I could not cover the case with async enhanced object literals, cause in travis CI you have nodejs 4 tests
```js
var obj = { async foo() {} };
```

Fix #33