### PR TITLE
Enhanced object literals don't have arrows

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ var PLACE_HOLDER_REGEXP = new RegExp('"@__(F|R|D|M|S)-' + UID + '-(\\d+)__@"', '
 
 var IS_NATIVE_CODE_REGEXP = /\{\s*\[native code\]\s*\}/g;
 var IS_PURE_FUNCTION = /function.*?\(/;
-var IS_ARROW_FUNCTION = /.+?=>.+?/;
+var IS_ARROW_FUNCTION = /.*?=>.*?/;
 var UNSAFE_CHARS_REGEXP   = /[<>\/\u2028\u2029]/g;
 
 var RESERVED_SYMBOLS = ['*', 'async'];

--- a/index.js
+++ b/index.js
@@ -12,6 +12,7 @@ var PLACE_HOLDER_REGEXP = new RegExp('"@__(F|R|D|M|S)-' + UID + '-(\\d+)__@"', '
 
 var IS_NATIVE_CODE_REGEXP = /\{\s*\[native code\]\s*\}/g;
 var IS_PURE_FUNCTION = /function.*?\(/;
+var IS_ARROW_FUNCTION = /.+?=>.+?/;
 var UNSAFE_CHARS_REGEXP   = /[<>\/\u2028\u2029]/g;
 
 var RESERVED_SYMBOLS = ['*', 'async'];
@@ -89,6 +90,11 @@ module.exports = function serialize(obj, options) {
 
       // pure functions, example: {key: function() {}}
       if(IS_PURE_FUNCTION.test(serializedFn)) {
+          return serializedFn;
+      }
+
+      // arrow functions, example: arg1 => arg1+5
+      if(IS_ARROW_FUNCTION.test(serializedFn)) {
           return serializedFn;
       }
 

--- a/test/unit/serialize.js
+++ b/test/unit/serialize.js
@@ -127,13 +127,25 @@ describe('serialize( obj )', function () {
         });
 
         it('should serialize functions that contain dates', function () {
-            var fn = function(arg1) {return new Date('2016-04-28T22:02:17.156Z')};
-            expect(serialize(fn)).to.be.a('string').equal('function(arg1) {return new Date(\'2016-04-28T22:02:17.156Z\')}');
+           function fn(arg1) {return new Date('2016-04-28T22:02:17.156Z')};
+            expect(serialize(fn)).to.be.a('string').equal('function fn(arg1) {return new Date(\'2016-04-28T22:02:17.156Z\')}');
+        });
+
+        it('should deserialize functions that contain dates', function () {
+            var fn; eval('fn = ' + serialize(function () { return new Date('2016-04-28T22:02:17.156Z') }));
+            expect(fn).to.be.a('function');
+            expect(fn().getTime()).to.equal(new Date('2016-04-28T22:02:17.156Z').getTime());
         });
 
         it('should serialize functions that return other functions', function () {
-            var fn = function(arg1) {return function(arg1) {return arg1 + 5}};
-            expect(serialize(fn)).to.be.a('string').equal('function(arg1) {return function(arg1) {return arg1 + 5}}');
+            function fn() {return function(arg1) {return arg1 + 5}};
+            expect(serialize(fn)).to.be.a('string').equal('function fn() {return function(arg1) {return arg1 + 5}}');
+        });
+
+        it('should deserialize functions that return other functions', function () {
+            var fn; eval('fn = ' + serialize(function () { return function(arg1) {return arg1 + 5} }));
+            expect(fn).to.be.a('function');
+            expect(fn()(7)).to.equal(12);
         });
     });
 
@@ -144,9 +156,9 @@ describe('serialize( obj )', function () {
         });
 
         it('should deserialize arrow functions', function () {
-            var fn; eval('fn = ' + serialize(() => {}));
+            var fn; eval('fn = ' + serialize(() => true));
             expect(fn).to.be.a('function');
-            expect(fn.name).to.equal('fn');
+            expect(fn()).to.equal(true);
         });
 
         it('should serialize arrow functions with one argument', function () {
@@ -157,7 +169,7 @@ describe('serialize( obj )', function () {
         it('should deserialize arrow functions with one argument', function () {
             var fn; eval('fn = ' + serialize(arg1 => {}));
             expect(fn).to.be.a('function');
-            expect(fn.name).to.equal('fn');
+            expect(fn.length).to.equal(1);
         });
 
         it('should serialize arrow functions with multiple arguments', function () {
@@ -211,10 +223,22 @@ describe('serialize( obj )', function () {
             expect(serialize(fn)).to.be.a('string').equal('() => {}');
         });
 
-     it('should serialize arrow functions that return other functions', function () {
-        var fn = arg1 => {return () => {}};
-        expect(serialize(fn)).to.be.a('string').equal('arg1 => {return () => {}}');
-      });
+        it('should deserialize arrow functions with added properties', function () {
+            var fn; eval('fn = ' + serialize( () => { this.property1 = 'a string'; return 5 }));
+            expect(fn).to.be.a('function');
+            expect(fn()).to.equal(5);
+        });
+
+         it('should serialize arrow functions that return other functions', function () {
+            var fn = arg1 => { return arg2 => arg1 + arg2 };
+            expect(serialize(fn)).to.be.a('string').equal('arg1 => { return arg2 => arg1 + arg2 }');
+          });
+
+        it('should deserialize arrow functions that return other functions', function () {
+            var fn; eval('fn = ' + serialize(arg1 => { return arg2 => arg1 + arg2 } ));
+            expect(fn).to.be.a('function');
+            expect(fn(2)(3)).to.equal(5);
+        });
     });
 
     describe('regexps', function () {

--- a/test/unit/serialize.js
+++ b/test/unit/serialize.js
@@ -125,6 +125,96 @@ describe('serialize( obj )', function () {
 
             expect(obj.hello()).to.equal(true);
         });
+
+        it('should serialize functions that contain dates', function () {
+            var fn = function(arg1) {return new Date('2016-04-28T22:02:17.156Z')};
+            expect(serialize(fn)).to.be.a('string').equal('function(arg1) {return new Date(\'2016-04-28T22:02:17.156Z\')}');
+        });
+
+        it('should serialize functions that return other functions', function () {
+            var fn = function(arg1) {return function(arg1) {return arg1 + 5}};
+            expect(serialize(fn)).to.be.a('string').equal('function(arg1) {return function(arg1) {return arg1 + 5}}');
+        });
+    });
+
+    describe('arrow-functions', function () {
+        it('should serialize arrow functions', function () {
+            var fn = () => {};
+            expect(serialize(fn)).to.be.a('string').equal('() => {}');
+        });
+
+        it('should deserialize arrow functions', function () {
+            var fn; eval('fn = ' + serialize(() => {}));
+            expect(fn).to.be.a('function');
+            expect(fn.name).to.equal('fn');
+        });
+
+        it('should serialize arrow functions with one argument', function () {
+            var fn = arg1 => {}
+            expect(serialize(fn)).to.be.a('string').equal('arg1 => {}');
+        });
+
+        it('should deserialize arrow functions with one argument', function () {
+            var fn; eval('fn = ' + serialize(arg1 => {}));
+            expect(fn).to.be.a('function');
+            expect(fn.name).to.equal('fn');
+        });
+
+        it('should serialize arrow functions with multiple arguments', function () {
+            var fn = (arg1, arg2) => {}
+            expect(serialize(fn)).to.equal('(arg1, arg2) => {}');
+        });
+
+        it('should deserialize arrow functions with multiple arguments', function () {
+            var fn; eval('fn = ' + serialize( (arg1, arg2) => {}));
+            expect(fn).to.be.a('function');
+            expect(fn.length).to.equal(2);
+        });
+
+        it('should serialize arrow functions with bodies', function () {
+            var fn = () => { return true; }
+            expect(serialize(fn)).to.equal('() => { return true; }');
+        });
+
+        it('should deserialize arrow functions with bodies', function () {
+            var fn; eval('fn = ' + serialize( () => { return true; }));
+            expect(fn).to.be.a('function');
+            expect(fn()).to.equal(true);
+        });
+
+        it('should serialize enhanced literal objects', function () {
+            var obj = {
+                foo: () => { return true; },
+                bar: arg1 => { return true; },
+                baz: (arg1, arg2) => { return true; }
+            };
+
+            expect(serialize(obj)).to.equal('{"foo":() => { return true; },"bar":arg1 => { return true; },"baz":(arg1, arg2) => { return true; }}');
+        });
+
+        it('should deserialize enhanced literal objects', function () {
+            var obj;
+            eval('obj = ' + serialize({                foo: () => { return true; },
+                foo: () => { return true; },
+                bar: arg1 => { return true; },
+                baz: (arg1, arg2) => { return true; }
+            }));
+
+            expect(obj.foo()).to.equal(true);
+            expect(obj.bar('arg1')).to.equal(true);
+            expect(obj.baz('arg1', 'arg1')).to.equal(true);
+        });
+
+        it('should serialize arrow functions with added properties', function () {
+            var fn = () => {};
+            fn.property1 = 'a string'
+            expect(serialize(fn)).to.be.a('string').equal('() => {}');
+        });
+
+     it('should serialize arrow functions that return other functions', function () {
+        var fn = arg1 => {return () => {}};
+        expect(serialize(fn)).to.be.a('string').equal('arg1 => {return () => {}}');
+      });
     });
 
     describe('regexps', function () {
@@ -195,6 +285,12 @@ describe('serialize( obj )', function () {
             var d = eval(serialize('2016-04-28T25:02:17.156Z'));
             expect(d).to.be.a('string');
             expect(d).to.equal('2016-04-28T25:02:17.156Z');
+        });
+
+        it('should serialize dates within objects', function () {
+            var d = {foo: new Date('2016-04-28T22:02:17.156Z')};
+            expect(serialize(d)).to.be.a('string').equal('{"foo":new Date("2016-04-28T22:02:17.156Z")}');
+            expect(serialize({t: [d]})).to.be.a('string').equal('{"t":[{"foo":new Date("2016-04-28T22:02:17.156Z")}]}');
         });
     });
 


### PR DESCRIPTION
Fixes a bug in serializeFunc. I added several unit tests until I could replicate the behavior. I think the extra unit tests are useful, but feel free to delete or alter any of them


<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
