### PR TITLE
Feat. New option `ignoreFunction` according to issue#32

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,13 +101,17 @@ serialize(obj, {isJSON: true});
 
 This option is to signal `serialize()` that we want to do a straight conversion, without the XSS protection. This options needs to be explicitly set to `true`. HTML characters and JavaScript line terminators will not be escaped. You will have to roll your own.
 
+```js
+serialize(obj, {unsafe: true});
+```
+
 #### `options.ignoreFunction`
 
 This option is to signal `serialize()` that we do not want serialize JavaScript function. 
 Just treat function like `JSON.stringify` do, but other features will work as expected.
 
 ```js
-serialize(obj, {unsafe: true});
+serialize(obj, {ignoreFunction: true});
 ```
 
 ## Deserializing

--- a/README.md
+++ b/README.md
@@ -101,6 +101,11 @@ serialize(obj, {isJSON: true});
 
 This option is to signal `serialize()` that we want to do a straight conversion, without the XSS protection. This options needs to be explicitly set to `true`. HTML characters and JavaScript line terminators will not be escaped. You will have to roll your own.
 
+#### `options.ignoreFunction`
+
+This option is to signal `serialize()` that we do not want serialize JavaScript function. 
+Just treat function like `JSON.stringify` do, but other features will work as expected.
+
 ```js
 serialize(obj, {unsafe: true});
 ```

--- a/index.js
+++ b/index.js
@@ -31,6 +31,22 @@ function escapeUnsafeChars(unsafeChar) {
     return ESCAPED_CHARS[unsafeChar];
 }
 
+function deleteFunctions(obj){
+    var functionKeys = []
+    for(var key in obj){
+        if(typeof obj[key] === 'function'){
+            functionKeys.push(key);
+        }
+    }
+    for(var i=0; i<functionKeys.length; i++){
+        delete obj[functionKeys[i]]
+    }
+    // Object.keys(obj)
+    // .filter(key => typeof obj[key] === "function")
+    // .forEach(functionKey => {
+    //   delete obj[functionKey];
+    // });
+}
 module.exports = function serialize(obj, options) {
     options || (options = {});
 
@@ -49,7 +65,9 @@ module.exports = function serialize(obj, options) {
     // Returns placeholders for functions and regexps (identified by index)
     // which are later replaced by their string representation.
     function replacer(key, value) {
-
+        if(options.ignoreFunction){
+            deleteFunctions(value);
+        }
         if (!value && value !== undefined) {
             return value;
         }
@@ -125,6 +143,9 @@ module.exports = function serialize(obj, options) {
       return serializedFn;
     }
 
+    if( options.ignoreFunction && typeof obj==='function'){
+        obj = undefined;
+    }
     // Protects against `JSON.stringify()` returning `undefined`, by serializing
     // to the literal string: "undefined".
     if (obj === undefined) {

--- a/index.js
+++ b/index.js
@@ -34,12 +34,12 @@ function escapeUnsafeChars(unsafeChar) {
 function deleteFunctions(obj){
     var functionKeys = [];
     for (var key in obj) {
-      if (typeof obj[key] === "function") {
-        functionKeys.push(key);
-      }
+        if (typeof obj[key] === "function") {
+            functionKeys.push(key);
+        }
     }
     for (var i = 0; i < functionKeys.length; i++) {
-      delete obj[functionKeys[i]];
+        delete obj[functionKeys[i]];
     }
 }
 
@@ -144,7 +144,7 @@ module.exports = function serialize(obj, options) {
 
     // Check if the parameter is function
     if (options.ignoreFunction && typeof obj === "function") {
-      obj = undefined;
+        obj = undefined;
     }
     // Protects against `JSON.stringify()` returning `undefined`, by serializing
     // to the literal string: "undefined".

--- a/index.js
+++ b/index.js
@@ -41,12 +41,8 @@ function deleteFunctions(obj){
     for(var i=0; i<functionKeys.length; i++){
         delete obj[functionKeys[i]]
     }
-    // Object.keys(obj)
-    // .filter(key => typeof obj[key] === "function")
-    // .forEach(functionKey => {
-    //   delete obj[functionKey];
-    // });
 }
+
 module.exports = function serialize(obj, options) {
     options || (options = {});
 
@@ -65,9 +61,12 @@ module.exports = function serialize(obj, options) {
     // Returns placeholders for functions and regexps (identified by index)
     // which are later replaced by their string representation.
     function replacer(key, value) {
+
+        // For nested function
         if(options.ignoreFunction){
             deleteFunctions(value);
         }
+
         if (!value && value !== undefined) {
             return value;
         }
@@ -143,6 +142,7 @@ module.exports = function serialize(obj, options) {
       return serializedFn;
     }
 
+    // Check if the parameter is function
     if( options.ignoreFunction && typeof obj==='function'){
         obj = undefined;
     }

--- a/index.js
+++ b/index.js
@@ -32,14 +32,14 @@ function escapeUnsafeChars(unsafeChar) {
 }
 
 function deleteFunctions(obj){
-    var functionKeys = []
-    for(var key in obj){
-        if(typeof obj[key] === 'function'){
-            functionKeys.push(key);
-        }
+    var functionKeys = [];
+    for (var key in obj) {
+      if (typeof obj[key] === "function") {
+        functionKeys.push(key);
+      }
     }
-    for(var i=0; i<functionKeys.length; i++){
-        delete obj[functionKeys[i]]
+    for (var i = 0; i < functionKeys.length; i++) {
+      delete obj[functionKeys[i]];
     }
 }
 
@@ -143,8 +143,8 @@ module.exports = function serialize(obj, options) {
     }
 
     // Check if the parameter is function
-    if( options.ignoreFunction && typeof obj==='function'){
-        obj = undefined;
+    if (options.ignoreFunction && typeof obj === "function") {
+      obj = undefined;
     }
     // Protects against `JSON.stringify()` returning `undefined`, by serializing
     // to the literal string: "undefined".

--- a/test/unit/serialize.js
+++ b/test/unit/serialize.js
@@ -424,6 +424,24 @@ describe('serialize( obj )', function () {
             expect(serialize(["<"], {space: 2})).to.equal('[\n  "\\u003C"\n]');
             expect(serialize(["<"], {unsafe: true, space: 2})).to.equal('[\n  "<"\n]');
         });
+
+        it("should accept a `ignoreFunction` option", function() {
+            function fn() { return true; }
+            const obj = {
+              fn,
+              fn_arrow: () => {
+                return true;
+              }
+            };            
+            const obj2 = {
+                num:123,
+                str:'str',
+                fn
+            }
+            expect(serialize(fn, { ignoreFunction: true })).to.equal(`undefined`);
+            expect(serialize(obj, { ignoreFunction: true })).to.equal("{}");
+            expect(serialize(obj2,{ignoreFunction:true})).to.equal(`{"num":123,"str":"str"}`);
+        });
     });
 
     describe('backwards-compatability', function () {

--- a/test/unit/serialize.js
+++ b/test/unit/serialize.js
@@ -427,24 +427,24 @@ describe('serialize( obj )', function () {
 
         it("should accept a `ignoreFunction` option", function() {
             function fn() { return true; }
-            const obj = {
-              fn,
-              fn_arrow: () => {
-                return true;
-              }
+            var obj = {
+                fn: fn,
+                fn_arrow: () => {
+                    return true;
+                }
             };            
-            const obj2 = {
-                num:123,
-                str:'str',
-                fn
+            var obj2 = {
+                num: 123,
+                str: 'str',
+                fn: fn
             }
             // case 1. Pass function to serialize
-            expect(serialize(fn, { ignoreFunction: true })).to.equal(`undefined`);
+            expect(serialize(fn, { ignoreFunction: true })).to.equal('undefined');
             // case 2. Pass function(arrow) in object to serialze
-            expect(serialize(obj, { ignoreFunction: true })).to.equal("{}");
+            expect(serialize(obj, { ignoreFunction: true })).to.equal('{}');
             // case 3. Other features should work
             expect(serialize(obj2, { ignoreFunction: true })).to.equal(
-              `{"num":123,"str":"str"}`
+              '{"num":123,"str":"str"}'
             );
         });
     });

--- a/test/unit/serialize.js
+++ b/test/unit/serialize.js
@@ -438,9 +438,14 @@ describe('serialize( obj )', function () {
                 str:'str',
                 fn
             }
+            // case 1. Pass function to serialize
             expect(serialize(fn, { ignoreFunction: true })).to.equal(`undefined`);
+            // case 2. Pass function(arrow) in object to serialze
             expect(serialize(obj, { ignoreFunction: true })).to.equal("{}");
-            expect(serialize(obj2,{ignoreFunction:true})).to.equal(`{"num":123,"str":"str"}`);
+            // case 3. Other features should work
+            expect(serialize(obj2, { ignoreFunction: true })).to.equal(
+              `{"num":123,"str":"str"}`
+            );
         });
     });
 


### PR DESCRIPTION
<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

According to this issue https://github.com/yahoo/serialize-javascript/issues/32 , I add a new option `ignoreFunction` for serialize.
```javascript
function fn(){ return true; }
serialize( fn , { ignoreFunction:true}) // 'undefined'
serialize({
    num:123,
    fn
},{ignoreFunction:true}); // `{"num":123}`
```
- [x] Add feature
- [x] Write test case
- [x] Update document