### PR TITLE
Ignore .nyc_output

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -4,3 +4,4 @@ test/
 .gitignore
 .npmignore
 .travis.yml
+.nyc_output


### PR DESCRIPTION
<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

Looks like `.nyc_output` was [published in v2.1.1](https://packagephobia.now.sh/result?p=serialize-javascript@2.1.1). Compare these two:

- 2.1.0: https://unpkg.com/browse/serialize-javascript@2.1.0/
- 2.1.1: https://unpkg.com/browse/serialize-javascript@2.1.1/
