### PR TITLE
Use fallback UID generation when main function failed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .nyc_output
 coverage
 node_modules
+.idea/

--- a/index.js
+++ b/index.js
@@ -35,12 +35,20 @@ function escapeUnsafeChars(unsafeChar) {
 }
 
 function generateUID() {
-    var bytes = randomBytes(UID_LENGTH);
-    var result = '';
-    for(var i=0; i<UID_LENGTH; ++i) {
-        result += bytes[i].toString(16);
+    try {
+        var bytes = randomBytes(UID_LENGTH);
+        var result = '';
+        for(var i=0; i<UID_LENGTH; ++i) {
+            result += bytes[i].toString(16);
+        }
+        return result;
+    } catch (e) {
+        return generateFallbackUID();
     }
-    return result;
+}
+
+function generateFallbackUID() {
+    return Math.floor(Math.random() * 0x10000000000).toString(16);
 }
 
 function deleteFunctions(obj){


### PR DESCRIPTION
The `randombytes` library may throw an error if the browser does not support the [crypto](https://developer.mozilla.org/en-US/docs/Web/API/Window/crypto). Probably, the good solution in this case would be using the old way of building an UID (took it from [here](https://github.com/yahoo/serialize-javascript/pull/79/files#diff-e727e4bdf3657fd1d798edcd6b099d6e092f8573cba266154583a746bba0f346L10)) rather than stopping execution with a third-party library error.


<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
