### PR TITLE
Add support for URL's

### DIFF
--- a/test/unit/serialize.js
+++ b/test/unit/serialize.js
@@ -452,6 +452,20 @@ describe('serialize( obj )', function () {
         });
     });
 
+    describe('URL', function () {
+        it('should serialize URL', function () {
+            var u = new URL('https://x.com/')
+            expect(serialize(u)).to.equal('new URL("https://x.com/")');
+            expect(serialize({t: [u]})).to.be.a('string').equal('{"t":[new URL("https://x.com/")]}');
+        });
+
+        it('should deserialize URL', function () {
+            var d = eval(serialize(new URL('https://x.com/')));
+            expect(d).to.be.a('URL');
+            expect(d.toString()).to.equal('https://x.com/');
+        });
+    });
+
     describe('XSS', function () {
         it('should encode unsafe HTML chars to Unicode', function () {
             expect(serialize('</script>')).to.equal('"\\u003C\\u002Fscript\\u003E"');


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

This PR adds support for the built-in [URL](https://developer.mozilla.org/en-US/docs/Web/API/URL) type. This is supported everywhere `Set` and `Map` are supported so I don't think compatibility should be an issue.

As far as how the actual value is serialized: the string-ified URL value itself is **not** escaped because `URL` will do this for us e.g. `(new URL("https://script>.com")).toString()` ➡️ `"https://script%3E.com/"`.