### PR TITLE
Compatibility with older versions of NodeJS

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ See the accompanying LICENSE file for terms.
 'use strict';
 
 var randomBytes = require('randombytes');
+var URL = require('url').URL;
 
 // Generate an internal UID to make the regexp pattern harder to guess.
 var UID_LENGTH          = 16;
@@ -116,6 +117,7 @@ module.exports = function serialize(obj, options) {
                 }
             }
 
+            try{
             if(origValue instanceof URL) {
                 return '@__L-' + UID + '-' + (urls.push(origValue) - 1) + '__@';
             }

--- a/index.js
+++ b/index.js
@@ -117,7 +117,6 @@ module.exports = function serialize(obj, options) {
                 }
             }
 
-            try{
             if(origValue instanceof URL) {
                 return '@__L-' + UID + '-' + (urls.push(origValue) - 1) + '__@';
             }


### PR DESCRIPTION
In older versions of NodeJS URL had to be imported.
In the new ones it is global but importing it isn't a mistake.


<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
