### PR TITLE
Fix serialization issue for 0n.

### DIFF
--- a/index.js
+++ b/index.js
@@ -83,7 +83,7 @@ module.exports = function serialize(obj, options) {
             deleteFunctions(value);
         }
 
-        if (!value && value !== undefined) {
+        if (!value && value !== undefined && value !== BigInt(0)) {
             return value;
         }
 

--- a/test/unit/serialize.js
+++ b/test/unit/serialize.js
@@ -441,6 +441,12 @@ describe('serialize( obj )', function () {
             expect(serialize({t: [b]})).to.be.a('string').equal('{"t":[BigInt("9999")]}');
         });
 
+        it('should serialize 0n', function () {
+            var b = BigInt(0);
+            expect(serialize(b)).to.equal('BigInt("0")');
+            expect(serialize({t: [b]})).to.be.a('string').equal('{"t":[BigInt("0")]}');
+        });
+
         it('should deserialize BigInt', function () {
             var d = eval(serialize(BigInt(9999)));
             expect(d).to.be.a('BigInt');


### PR DESCRIPTION
Falsy values except `0n` are directly serializable by `JSON.stringify`; therefore exclude `0n` from the early return which checks for falsy values.

---

Fix yahoo/serialize-javascript#125
Fix yahoo/serialize-javascript#154

---

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
