### PR TITLE
Use Function Objects for deserialization, instead of eval

### DIFF
--- a/index.js
+++ b/index.js
@@ -55,7 +55,11 @@ function deleteFunctions(obj){
     }
 }
 
-module.exports = function serialize(obj, options) {
+module.exports.deserialize = function(objStr){
+    return new Function("return " + objStr)();
+};
+
+module.exports.serialize = function serialize(obj, options) {
     options || (options = {});
 
     // Backwards-compatibility for `space` as the second argument.


### PR DESCRIPTION
<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
