### PR TITLE
Serialize URL string contents to prevent XSS

### DIFF
--- a/index.js
+++ b/index.js
@@ -258,7 +258,7 @@ module.exports = function serialize(obj, options) {
         }
 
         if (type === 'L') {
-            return "new URL(\"" + urls[valueIndex].toString() + "\")"; 
+            return "new URL(" + serialize(urls[valueIndex].toString(), options) + ")";
         }
 
         var fn = functions[valueIndex];

--- a/test/unit/serialize.js
+++ b/test/unit/serialize.js
@@ -461,8 +461,8 @@ describe('serialize( obj )', function () {
     describe('URL', function () {
         it('should serialize URL', function () {
             var u = new URL('https://x.com/')
-            expect(serialize(u)).to.equal('new URL("https://x.com/")');
-            expect(serialize({t: [u]})).to.be.a('string').equal('{"t":[new URL("https://x.com/")]}');
+            expect(serialize(u)).to.equal('new URL("https:\\u002F\\u002Fx.com\\u002F")');
+            expect(serialize({t: [u]})).to.be.a('string').equal('{"t":[new URL("https:\\u002F\\u002Fx.com\\u002F")]}');
         });
 
         it('should deserialize URL', function () {
@@ -477,6 +477,8 @@ describe('serialize( obj )', function () {
             expect(serialize('</script>')).to.equal('"\\u003C\\u002Fscript\\u003E"');
             expect(JSON.parse(serialize('</script>'))).to.equal('</script>');
             expect(eval(serialize('</script>'))).to.equal('</script>');
+            expect(serialize(new URL('x:</script>'))).to.equal('new URL("x:\\u003C\\u002Fscript\\u003E")');
+            expect(eval(serialize(new URL('x:</script>'))).href).to.equal('x:</script>');
         });
     });
 


### PR DESCRIPTION
<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

Fixes #172 by implementing @redonkulus's excellent suggestion. Additionally updates the tests to expect the newly encoded URL values, and adds a new test to ensure the serialized output does not contain any unsafe characters.

Thanks again to @redonkulus for finding and suggesting the fix!