### PR TITLE
Generate UID without randombytes dependency

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [20.x, 22.x]
+        node-version: [20.x, 22.x, 24.x]
     steps:
       - uses: actions/checkout@v3
       - name: Use Node.js ${{ matrix.node-version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [18.x, 20.x, 22.x]
+        node-version: [20.x, 22.x]
     steps:
       - uses: actions/checkout@v3
       - name: Use Node.js ${{ matrix.node-version }}

--- a/index.js
+++ b/index.js
@@ -33,20 +33,7 @@ function escapeUnsafeChars(unsafeChar) {
 }
 
 function generateUID() {
-    var bytes;
-    if (typeof crypto !== 'undefined' && typeof crypto.getRandomValues === 'function') {
-        bytes = crypto.getRandomValues(new Uint8Array(UID_LENGTH));
-    } else {
-        try {
-            var nodeCrypto = require('crypto');
-            bytes = nodeCrypto.randomBytes(UID_LENGTH);
-        } catch {
-            // We'll throw an error later
-        }
-    }
-    if (!bytes) {
-        throw new Error('Secure random number generation is not supported by this platform.');
-    }
+    var bytes = crypto.getRandomValues(new Uint8Array(UID_LENGTH));
     var result = '';
     for(var i=0; i<UID_LENGTH; ++i) {
         result += bytes[i].toString(16);

--- a/index.js
+++ b/index.js
@@ -6,8 +6,6 @@ See the accompanying LICENSE file for terms.
 
 'use strict';
 
-var randomBytes = require('randombytes');
-
 // Generate an internal UID to make the regexp pattern harder to guess.
 var UID_LENGTH          = 16;
 var UID                 = generateUID();
@@ -35,7 +33,20 @@ function escapeUnsafeChars(unsafeChar) {
 }
 
 function generateUID() {
-    var bytes = randomBytes(UID_LENGTH);
+    var bytes;
+    if (typeof crypto !== 'undefined' && typeof crypto.getRandomValues === 'function') {
+        bytes = crypto.getRandomValues(new Uint8Array(UID_LENGTH));
+    } else {
+        try {
+            var nodeCrypto = require('crypto');
+            bytes = nodeCrypto.randomBytes(UID_LENGTH);
+        } catch {
+            // We'll throw an error later
+        }
+    }
+    if (!bytes) {
+        throw new Error('Secure random number generation is not supported by this platform.');
+    }
     var result = '';
     for(var i=0; i<UID_LENGTH; ++i) {
         result += bytes[i].toString(16);

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,9 @@
       "license": "BSD-3-Clause",
       "devDependencies": {
         "benchmark": "^2.1.4"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/benchmark": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,6 @@
       "name": "serialize-javascript",
       "version": "6.0.2",
       "license": "BSD-3-Clause",
-      "dependencies": {
-        "randombytes": "^2.1.0"
-      },
       "devDependencies": {
         "benchmark": "^2.1.4"
       }
@@ -36,19 +33,6 @@
       "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.5.tgz",
       "integrity": "sha512-TuvHS8AOIZNAlE77WUDiR4rySV/VMptyMfcfeoMgs4P8apaZM3JrnbzBiixKUv+XR6i+BXrQh8WAnjaSPFO65Q==",
       "dev": true
-    },
-    "node_modules/randombytes": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-      "dependencies": {
-        "safe-buffer": "^5.1.0"
-      }
-    },
-    "node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -26,5 +26,8 @@
   "homepage": "https://github.com/yahoo/serialize-javascript",
   "devDependencies": {
     "benchmark": "^2.1.4"
+  },
+  "engines": {
+    "node": ">=20.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -26,8 +26,5 @@
   "homepage": "https://github.com/yahoo/serialize-javascript",
   "devDependencies": {
     "benchmark": "^2.1.4"
-  },
-  "dependencies": {
-    "randombytes": "^2.1.0"
   }
 }

--- a/test/unit/serialize.js
+++ b/test/unit/serialize.js
@@ -3,20 +3,6 @@ const { deepStrictEqual, strictEqual, throws } = require('node:assert');
 
 var serialize = require('../../');
 
-// temporarily monkeypatch `crypto.randomBytes` so we'll have a
-// predictable UID for our tests
-var crypto = require('crypto');
-var oldRandom = crypto.randomBytes;
-crypto.randomBytes = function(len, cb) {
-    var buf = Buffer.alloc(len);
-    buf.fill(0x00);
-    if (cb)
-        cb(null, buf);
-    return buf;
-};
-
-crypto.randomBytes = oldRandom;
-
 describe('serialize( obj )', function () {
     it('should be a function', function () {
         strictEqual(typeof serialize, 'function');


### PR DESCRIPTION
<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

Resolves #134. Instead of taking an external dependency on `randombytes`, which accesses `global` (doesn't work in the browser) and depends on a `Buffer` polyfill, we check first for `crypto.getRandomValues` support and only import Node's `crypto` module if it's not found.

If you're OK with dropping support for Node <19, the `crypto` global is available in newer versions of Node (it technically didn't stop being "experimental" until Node 23, but I don't get any annoying `ExperimentalWarning` messages when trying to access it in older versions).

An alternative option would be to add separate browser and Node entrypoints; this would avoid the dynamic `require` that might(?) cause trouble for some bundlers. I have [that code in a separate branch](https://github.com/valadaptive/serialize-javascript/commit/496e69ed61135afee86df2cd5f9d528dd3271de4) if you'd prefer it.