### PR TITLE
Add warning about using this package to send arbitrary data to worker threads

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,9 @@ The string returned from this package's single export function is literal JavaSc
 Please note that serialization for ES6 Sets & Maps requires support for `Array.from` (not available in IE or Node < 0.12), or an `Array.from` polyfill.
 
 > [!WARNING]
-> It may be tempting to use this package as a way to pass arbitrary functions into [worker threads](https://nodejs.org/api/worker_threads.html), since you cannot pass them directly via `postMessage()`. However, passing functions between worker threads is not possible in the general case. This package lets you serialize *some* functions, but it has limitations.
+> It may be tempting to use this package as a way to pass arbitrary functions into [worker threads][], since you cannot pass them directly via `postMessage()`. However, passing functions between worker threads is not possible in the general case. This package lets you serialize *some* functions, but it has limitations.
 >
-> For instance, if a function references something from outside the function body, it will not run properly if serialized and deserialized. This could include [closed-over variables](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Closures) or imports from other packages. For a serialized function to run properly, it must be entirely self-contained.
+> For instance, if a function references something from outside the function body, it will not run properly if serialized and deserialized. This could include [closed-over variables][] or imports from other packages. For a serialized function to run properly, it must be entirely self-contained.
 >
 > In general, it is not possible to send arbitrary JavaScript to a worker thread, and pretend it's running the same way it would run on the main thread. This package doesn't let you do that.
 
@@ -148,3 +148,5 @@ See the [LICENSE file][LICENSE] for license text and copyright information.
 [express-state]: https://github.com/yahoo/express-state
 [JSON.stringify]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify
 [LICENSE]: https://github.com/yahoo/serialize-javascript/blob/main/LICENSE
+[worker threads]: https://nodejs.org/api/worker_threads.html
+[closed-over variables]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Closures


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

---

I've discovered that many JavaScript packages use this package to try and send arbitrary data containing functions to worker threads, basically using it as a version of `postMessage()` that doesn't throw if there's a function in there somewhere. In particular, it seems to be used by developer tooling that wants to "transparently" start running things in parallel, passing a user-supplied configuration object into each worker thread. [Here's `@rollup/plugin-terser` using it](https://github.com/rollup/plugins/blob/c8e78c8584007999050f7d9878d87e15046bbf09/packages/terser/src/worker-pool.ts#L120-L125), and [here it is in Mocha, a popular testing framework](https://github.com/mochajs/mocha/blob/f75d150cf6115334e7f14b8ee1fbbda04eb87087/lib/nodejs/worker.js#L58-L148).

However, there's a very good reason for `postMessage()` to throw an error when encountering a function. Functions can, in general, reference data defined *outside* the function. Serializing that data would be quite difficult, and `serialize-javascript` just doesn't do it.

Using `serialize-javascript` to send arbitrary data to worker threads may work in simpler cases, but it fails as soon as the functions reference things like imported modules. I think we should make it clear that it's not magic, and doesn't let you treat worker threads the same way as the main thread. As such, this PR adds a disclaimer pretty high up in the readme.