### PR TITLE
Backport security fix for CVE‑2020‑7660 to v6.0.x

### DIFF
--- a/index.js
+++ b/index.js
@@ -226,11 +226,18 @@ module.exports = function serialize(obj, options) {
         }
 
         if (type === 'D') {
-            return "new Date(\"" + dates[valueIndex].toISOString() + "\")";
+            // Validate ISO string format to prevent code injection via spoofed toISOString()
+            var isoStr = String(dates[valueIndex].toISOString());
+            if (!/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d{3})?Z$/.test(isoStr)) {
+                throw new TypeError('Invalid Date ISO string');
+            }
+            return "new Date(\"" + isoStr + "\")";
         }
 
         if (type === 'R') {
-            return "new RegExp(" + serialize(regexps[valueIndex].source) + ", \"" + regexps[valueIndex].flags + "\")";
+            // Sanitize flags to prevent code injection (only allow valid RegExp flag characters)
+            var flags = String(regexps[valueIndex].flags).replace(/[^gimsuydv]/g, '');
+            return "new RegExp(" + serialize(regexps[valueIndex].source) + ", \"" + flags + "\")";
         }
 
         if (type === 'M') {

--- a/test/unit/serialize.js
+++ b/test/unit/serialize.js
@@ -316,6 +316,23 @@ describe('serialize( obj )', function () {
             var re = /[<\/script><script>alert('xss')\/\/]/
             expect(serialize(re)).to.be.a('string').equal('new RegExp("[\\u003C\\\\\\u002Fscript\\u003E\\u003Cscript\\u003Ealert(\'xss\')\\\\\\u002F\\\\\\u002F]", "")');
         });
+
+        it('should sanitize RegExp.flags to prevent code injection', function () {
+            // Object that passes instanceof RegExp with attacker-controlled .flags
+            var fakeRegex = Object.create(RegExp.prototype);
+            Object.defineProperty(fakeRegex, 'source', { get: function () { return 'x'; } });
+            Object.defineProperty(fakeRegex, 'flags', {
+                get: function () { return '"+(global.__INJECTED_FLAGS="pwned")+"'; }
+            });
+            fakeRegex.toJSON = function () { return '@placeholder'; };
+            var output = serialize({ re: fakeRegex });
+            // Malicious flags must be stripped; only valid flag chars allowed
+            strictEqual(output.includes('__INJECTED_FLAGS'), false);
+            strictEqual(output.includes('pwned'), false);
+            var obj = eval('obj = ' + output);
+            strictEqual(global.__INJECTED_FLAGS, undefined);
+            delete global.__INJECTED_FLAGS;
+        });
     });
 
     describe('dates', function () {
@@ -341,6 +358,16 @@ describe('serialize( obj )', function () {
             var d = {foo: new Date('2016-04-28T22:02:17.156Z')};
             expect(serialize(d)).to.be.a('string').equal('{"foo":new Date("2016-04-28T22:02:17.156Z")}');
             expect(serialize({t: [d]})).to.be.a('string').equal('{"t":[{"foo":new Date("2016-04-28T22:02:17.156Z")}]}');
+        });
+
+        it('should reject invalid Date ISO string to prevent code injection', function () {
+            var fakeDate = Object.create(Date.prototype);
+            fakeDate.toISOString = function () { return '"+(global.__INJECTED_DATE="pwned")+"'; };
+            fakeDate.toJSON = function () { return '2024-01-01'; };
+            throws(function () {
+                serialize({ d: fakeDate });
+            }, TypeError);
+            strictEqual(global.__INJECTED_DATE, undefined);
         });
     });
 

--- a/test/unit/serialize.js
+++ b/test/unit/serialize.js
@@ -13,6 +13,13 @@ crypto.randomBytes = function(len, cb) {
     return buf;
 };
 
+// require strictEqual and throws for testing that
+// malicious input does not cause code injection
+var _assert = require('node:assert/strict');
+var strictEqual = _assert.strictEqual;
+var throws = _assert.throws;
+
+
 var serialize = require('../../'),
     expect    = require('chai').expect;
 


### PR DESCRIPTION
### Summary

This PR backports the security fix introduced in v7.0.3 to the v6.0.2 codebase.

Versions up to v7.0.2 correctly sanitize RegExp.source, but RegExp.flags is still interpolated into generated output without validation or escaping. Additionally, Date.prototype.toISOString() follows the same code path and can be attacker‑controlled.

When serialized output is later evaluated (e.g., via eval, new Function, script injection, etc.), it is possible for malicious values to trigger arbitrary JavaScript execution. This represents an incomplete remediation of the vulnerability originally addressed under CVE‑2020‑7660.

This backport applies the same sanitization and validation logic used in v7.0.3.

### Affected Versions

This PR specifically addresses the issue for the v6.x line (based on tag v6.0.2).

### Impact
This vulnerability allows improper neutralization of attacker‑controlled values during code generation, resulting in arbitrary JavaScript execution when the serialized output is evaluated.

If an attacker can influence objects passed into serialize(), they can inject code via:

- crafted RegExp.flags
- crafted Date.prototype.toISOString()

This backport ensures that:

- only valid RegExp flag characters are permitted
- unsafe characters and unexpected values are rejected
- invalid ISO date strings are detected and rejected
- attempts at injection do not reach generated output

All new tests from the 7.0.3 fix are included and passing.

### Request

Upstream currently maintains only the main branch.

This PR originates from a branch created off the v6.0.2 tag.

Could you please create a 6.0.x maintenance branch?

Once created, I will re‑target this PR so that it merges cleanly into the correct version line.
This will allow you to optionally publish a v6.0.3 release containing this security backport.

### Verification

- The patch is a faithful backport of the upstream 7.0.3 fix
- All tests pass, including the newly added security tests
- Behavior matches the latest patched release
- No breaking changes introduced for 6.x users

### License
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.