### PR TITLE
✨ Quality: Fix serialization of native functions like Number, String

### DIFF
--- a/index.js
+++ b/index.js
@@ -159,6 +159,9 @@ module.exports = function serialize(obj, options) {
     function serializeFunc(fn, options) {
       var serializedFn = fn.toString();
       if (IS_NATIVE_CODE_REGEXP.test(serializedFn)) {
+          if (fn.name) {
+              return fn.name;
+          }
           throw new TypeError('Serializing native function: ' + fn.name);
       }
 


### PR DESCRIPTION
## Problem

The issue is that serialize-javascript throws a TypeError when trying to serialize native functions (like `Number`, `String`, `Array`, etc.). The fix should detect native built-in constructors and serialize them by their name (e.g., `Number` instead of throwing an error).

**Severity**: `medium`
**File**: `index.js`

## Solution

The issue is that serialize-javascript throws a TypeError when trying to serialize native functions (like `Number`, `String`, `Array`, etc.). The fix should detect native built-in constructors and serialize them by their name (e.g., `Number` instead of throwing an error).

## Changes

- `index.js` (modified)

## Testing

- [x] Existing tests pass
- [x] Manual review completed
- [x] No new warnings/errors introduced


Closes #179