### PR TITLE
fix: reject spoofed URL objects with non-string toString() result

### DIFF
--- a/index.js
+++ b/index.js
@@ -287,7 +287,11 @@ module.exports = function serialize(obj, options) {
         }
 
         if (type === 'L') {
-            return "new URL(" + serialize(urls[valueIndex].toString(), options) + ")";
+            var urlStr = urls[valueIndex].toString();
+            if (typeof urlStr !== 'string') {
+                throw new TypeError('URL.toString() must return a string');
+            }
+            return "new URL(" + serialize(urlStr, options) + ")";
         }
 
         var fn = functions[valueIndex];

--- a/test/unit/serialize.js
+++ b/test/unit/serialize.js
@@ -535,6 +535,18 @@ describe('serialize( obj )', function () {
             strictEqual(d instanceof URL, true);
             strictEqual(d.toString(), 'https://x.com/');
         });
+
+        it('should throw when serializing a spoofed URL with non-string toString()', function () {
+            var fakeUrl = Object.create(URL.prototype);
+            fakeUrl.toString = function () {
+                return {
+                    toString: function () {
+                        return 'https://example.com/';
+                    }
+                };
+            };
+            throws(function () { serialize({ url: fakeUrl }); }, TypeError);
+        });
     });
 
     describe('XSS', function () {


### PR DESCRIPTION
Validates that URL.toString() returns a primitive string before passing to serialize(), preventing code injection via Object.create(URL.prototype) spoofing. Adds a regression test covering the attack vector from PSECBUGS-108653.


<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
