### PR TITLE
Add regression coverage for script close variants

### DIFF
--- a/test/unit/serialize.js
+++ b/test/unit/serialize.js
@@ -619,6 +619,34 @@ describe('serialize( obj )', function () {
             strictEqual(typeof deserialized, 'function');
             strictEqual(deserialized(), '</script\t>');
         });
+
+        it('should encode script close variants in function bodies', function () {
+            var payloads = [
+                '</script>',
+                '</SCRIPT>',
+                '</Script>',
+                '</script >',
+                '</script\\t>',
+                '</script\\n>',
+                '</script\\r>',
+                '</script\\f>',
+                '</script/x>',
+                '</script x>'
+            ];
+
+            payloads.forEach(function (payload) {
+                var fn = new Function('return ' + JSON.stringify(payload));
+                var serialized = serialize(fn);
+
+                strictEqual(serialized.includes('</script'), false);
+                strictEqual(serialized.includes('</SCRIPT'), false);
+                strictEqual(serialized.includes('</Script'), false);
+
+                var deserialized;
+                eval('deserialized = ' + serialized);
+                strictEqual(deserialized(), payload);
+            });
+        });
     });
 
     describe('options', function () {


### PR DESCRIPTION
This adds regression coverage for several script-closing variants inside serialized function bodies.

The existing XSS tests already cover common `</script>` cases. This expands coverage to mixed-case tags, whitespace variants, and attribute-like variants while also verifying that the serialized function still deserializes to the original payload.

Tested locally with:

npm test