### PR TITLE
feat: add Node.js 26 to test matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [20, 22, 24]
+        node-version: [20, 22, 24, 26]
     steps:
       - name: Checkout
         uses: actions/checkout@v6


### PR DESCRIPTION
## Why
Node.js 26 support should be covered in CI so compatibility issues are detected automatically when contributors open PRs.

## What changed
Updated the test workflow matrix to include Node.js 26 in addition to the existing Node.js 20, 22, and 24 versions.

## Notes
N/A