### PR TITLE
release: v7.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "serialize-javascript",
-  "version": "7.0.7",
+  "version": "7.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "serialize-javascript",
-      "version": "7.0.7",
+      "version": "7.1.0",
       "license": "BSD-3-Clause",
       "devDependencies": {
         "benchmark": "^2.1.4"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serialize-javascript",
-  "version": "7.0.7",
+  "version": "7.1.0",
   "description": "Serialize JavaScript to a superset of JSON that includes regular expressions and functions.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## Summary
Bumps the package version for the v7.1.0 release so the published metadata and lockfile stay in sync.

## Changes
- update `package.json` version from `7.0.7` to `7.1.0`
- refresh `package-lock.json` to match the release version

## Notes
N/A