### PR TITLE
fix: fix XSS bypass via split `</script` payload across function bodies

### DIFF
--- a/index.js
+++ b/index.js
@@ -73,8 +73,12 @@ function escapeUnsafeChars(unsafeChar) {
 //   subsequent string match; a division expression that happens to match
 //   this pattern is merely treated as opaque, which only risks an
 //   unnecessary (but still valid) unicode-escape rather than a
-//   miscalculated string boundary.
-var STRING_OR_COMMENT_REGEXP = /\/\*[\s\S]*?\*\/|\/\/[^\n]*|'(?:\\.|[^'\\])*'|"(?:\\.|[^"\\])*"|`(?:\\.|[^`\\])*`|\/(?:\\.|[^\/\\\n])+\//g;
+//   miscalculated string boundary. Bracket character classes (`[...]`) are
+//   matched as a unit so that an unescaped `/` inside one (valid and
+//   unremarkable in a regex literal, e.g. `/[/']/`) isn't mistaken for the
+//   literal's closing delimiter, which would otherwise end the match early
+//   and misalign whatever string/regex follows.
+var STRING_OR_COMMENT_REGEXP = /\/\*[\s\S]*?\*\/|\/\/[^\n]*|'(?:\\.|[^'\\])*'|"(?:\\.|[^"\\])*"|`(?:\\.|[^`\\])*`|\/(?:\\.|\[(?:\\.|[^\]\\\n])*\]|[^\/\\\n])+\//g;
 
 // Escape function body for XSS protection while preserving arrow function
 // syntax (=>), comparison operators, and regex literals: only script end

--- a/index.js
+++ b/index.js
@@ -54,25 +54,35 @@ function escapeUnsafeChars(unsafeChar) {
     return ESCAPED_CHARS[unsafeChar];
 }
 
-// Matches string literals, template literals, and comments so that
-// `escapeFunctionBody` can tell them apart from plain code (see below).
-// This is a lightweight heuristic, not a full parser: a whole template
-// literal (backtick to backtick) is treated as one opaque span, including
-// any `${...}` substitutions inside it. Known limitation: if a `</script`
-// sequence appears *inside* such a substitution (which is actual code, e.g.
-// `` `${ x</script/.test(x) }` ``), it will be misidentified as
-// string/template content and unicode-escaped, which can still produce a
-// SyntaxError. This is considered an acceptable trade-off for keeping this
-// scan simple; none of our tests hit this narrower case.
-var STRING_OR_COMMENT_REGEXP = /\/\*[\s\S]*?\*\/|\/\/[^\n]*|'(?:\\.|[^'\\])*'|"(?:\\.|[^"\\])*"|`(?:\\.|[^`\\])*`/g;
+// Matches string literals, template literals, regex literals, and comments
+// so that `escapeFunctionBody` can tell them apart from plain code (see
+// below). This is a lightweight heuristic, not a full parser:
+// - A whole template literal (backtick to backtick) is treated as one
+//   opaque span, including any `${...}` substitutions inside it. Known
+//   limitation: if a `</script` sequence appears *inside* such a
+//   substitution (which is actual code, e.g. `` `${ x</script/.test(x) }` ``),
+//   it will be misidentified as string/template content and
+//   unicode-escaped, which can still produce a SyntaxError. This is
+//   considered an acceptable trade-off for keeping this scan simple; none
+//   of our tests hit this narrower case.
+// - The regex-literal alternative can't reliably distinguish a real regex
+//   literal from a division expression (e.g. `a / b / c`), since that
+//   requires knowing the preceding token. It's included primarily so a
+//   quote character inside a genuine regex literal (e.g. `/'/`) isn't
+//   mistaken for the start of a string, which would misalign every
+//   subsequent string match; a division expression that happens to match
+//   this pattern is merely treated as opaque, which only risks an
+//   unnecessary (but still valid) unicode-escape rather than a
+//   miscalculated string boundary.
+var STRING_OR_COMMENT_REGEXP = /\/\*[\s\S]*?\*\/|\/\/[^\n]*|'(?:\\.|[^'\\])*'|"(?:\\.|[^"\\])*"|`(?:\\.|[^`\\])*`|\/(?:\\.|[^\/\\\n])+\//g;
 
 // Escape function body for XSS protection while preserving arrow function
 // syntax (=>), comparison operators, and regex literals: only script end
 // tags and line terminators are escaped.
 function escapeFunctionBody(str) {
     // Record the [start, end) span of every string literal, template
-    // literal, and comment so matches inside them can be treated
-    // differently from matches in plain code (see below).
+    // literal, regex literal, and comment so matches inside them can be
+    // treated differently from matches in plain code (see below).
     var stringAndCommentSpans = [];
     var match;
     STRING_OR_COMMENT_REGEXP.lastIndex = 0;
@@ -80,10 +90,18 @@ function escapeFunctionBody(str) {
         stringAndCommentSpans.push([match.index, match.index + match[0].length]);
     }
 
+    // Both the script-close matches (found below, in source order via
+    // `replace`) and `stringAndCommentSpans` are ordered by offset, so a
+    // single forward-moving cursor is enough to classify every match in
+    // O(n) total instead of re-scanning every span for every match.
+    var spanCursor = 0;
+
     str = str.replace(SCRIPT_CLOSE_REGEXP, function(scriptCloseMatch, offset) {
-        var inStringOrComment = stringAndCommentSpans.some(function(span) {
-            return offset >= span[0] && offset < span[1];
-        });
+        while (spanCursor < stringAndCommentSpans.length && stringAndCommentSpans[spanCursor][1] <= offset) {
+            spanCursor++;
+        }
+        var span = stringAndCommentSpans[spanCursor];
+        var inStringOrComment = !!span && offset >= span[0] && offset < span[1];
         if (!inStringOrComment) {
             // Outside of strings/templates/comments, `<` and `/` are real
             // JavaScript tokens (a comparison operator, a regex literal

--- a/index.js
+++ b/index.js
@@ -15,27 +15,15 @@ var IS_NATIVE_CODE_REGEXP = /\{\s*\[native code\]\s*\}/g;
 var IS_PURE_FUNCTION = /function.*?\(/;
 var IS_ARROW_FUNCTION = /.*?=>.*?/;
 var UNSAFE_CHARS_REGEXP   = /[<>\/\u2028\u2029]/g;
-// Matches a script end tag (case-insensitive) for XSS protection, in either
-// of two forms:
-//   1. `<\/script[^>]*>` - a complete `</script...>` tag within a single
-//      value, escaped in full (including the closing `>`).
-//   2. `<\/script(?=[\t\n\f\r \/>])` - a bare `</script` prefix followed by
-//      one of the characters (TAB, LF, FF, CR, SPACE, `/`, `>`) that the
-//      WHATWG HTML tokenizer's "script data end tag name state" treats as
-//      ending the tag name and starting end-tag recognition (see
-//      https://html.spec.whatwg.org/multipage/parsing.html#script-data-end-tag-name-state).
-//      Because that state only needs to see `</script` plus one such
-//      character to commit to end-tag parsing, the matching closing `>` can
-//      be supplied by a *different* serialized value later in the output, so
-//      the closing tag itself doesn't need to be present in the same match;
-//      escaping the prefix on its own closes that gap. A trailing backslash
-//      is intentionally NOT included: HTML tokenization happens before any
-//      JavaScript escape-sequence processing, so a literal backslash
-//      character is not itself a delimiter recognized by the tokenizer, and
-//      treating it as one would incorrectly alter the raw text of tagged
-//      template literals (e.g. `String.raw`).
-// The first alternative is tried first so a fully-formed tag (the common
-// case) is escaped as one unit, including its closing `>`.
+// Matches a script end tag (case-insensitive) for XSS protection: either a
+// full `</script...>` tag, or a bare `</script` followed by one of the
+// characters (TAB, LF, FF, CR, SPACE, `/`, `>`) that the HTML tokenizer
+// treats as ending the tag name (see the WHATWG "script data end tag name
+// state"). The bare-prefix form matters because the matching `>` could be
+// supplied by a different serialized value later in the output, so escaping
+// stops there without waiting for a closing `>`. A trailing backslash is not
+// a delimiter here (that's a JS-level concern, not an HTML one), so this
+// doesn't affect tagged template literals like `String.raw`.
 var SCRIPT_CLOSE_REGEXP = /<\/script[^>]*>|<\/script(?=[\t\n\f\r \/>])/gi;
 
 var RESERVED_SYMBOLS = ['*', 'async'];
@@ -54,39 +42,28 @@ function escapeUnsafeChars(unsafeChar) {
     return ESCAPED_CHARS[unsafeChar];
 }
 
-// Matches string literals, template literals, regex literals, and comments
-// so that `escapeFunctionBody` can tell them apart from plain code (see
-// below). This is a lightweight heuristic, not a full parser:
-// - A whole template literal (backtick to backtick) is treated as one
-//   opaque span, including any `${...}` substitutions inside it. Known
-//   limitation: if a `</script` sequence appears *inside* such a
-//   substitution (which is actual code, e.g. `` `${ x</script/.test(x) }` ``),
-//   it will be misidentified as string/template content and
-//   unicode-escaped, which can still produce a SyntaxError. This is
-//   considered an acceptable trade-off for keeping this scan simple; none
-//   of our tests hit this narrower case.
-// - The regex-literal alternative can't reliably distinguish a real regex
-//   literal from a division expression (e.g. `a / b / c`), since that
-//   requires knowing the preceding token. It's included primarily so a
-//   quote character inside a genuine regex literal (e.g. `/'/`) isn't
-//   mistaken for the start of a string, which would misalign every
-//   subsequent string match; a division expression that happens to match
-//   this pattern is merely treated as opaque, which only risks an
-//   unnecessary (but still valid) unicode-escape rather than a
-//   miscalculated string boundary. Bracket character classes (`[...]`) are
-//   matched as a unit so that an unescaped `/` inside one (valid and
-//   unremarkable in a regex literal, e.g. `/[/']/`) isn't mistaken for the
-//   literal's closing delimiter, which would otherwise end the match early
-//   and misalign whatever string/regex follows.
+// Roughly matches string literals, template literals, regex literals, and
+// comments, so `escapeFunctionBody` can treat their contents differently
+// from plain code. This is a heuristic, not a full parser, with two known
+// limitations:
+// - A template literal is treated as one opaque span, including any
+//   `${...}` inside it. A `</script`-like sequence inside such a
+//   substitution (real code) can be misclassified as string content.
+// - The regex-literal alternative can't tell a regex from division (e.g.
+//   `a / b / c`); a division expression that matches it is simply treated
+//   as opaque, which only risks an unnecessary (but valid) unicode-escape.
+//   It exists mainly so quotes and slashes inside a real regex (including
+//   inside a `[...]` character class) aren't mistaken for string/regex
+//   delimiters, which would misalign whatever follows.
 var STRING_OR_COMMENT_REGEXP = /\/\*[\s\S]*?\*\/|\/\/[^\n]*|'(?:\\.|[^'\\])*'|"(?:\\.|[^"\\])*"|`(?:\\.|[^`\\])*`|\/(?:\\.|\[(?:\\.|[^\]\\\n])*\]|[^\/\\\n])+\//g;
 
 // Escape function body for XSS protection while preserving arrow function
 // syntax (=>), comparison operators, and regex literals: only script end
 // tags and line terminators are escaped.
 function escapeFunctionBody(str) {
-    // Record the [start, end) span of every string literal, template
-    // literal, regex literal, and comment so matches inside them can be
-    // treated differently from matches in plain code (see below).
+    // Record the [start, end) span of every string/template/regex literal
+    // and comment, so a script-close match inside one can be escaped
+    // differently from a match in plain code (see below).
     var stringAndCommentSpans = [];
     var match;
     STRING_OR_COMMENT_REGEXP.lastIndex = 0;
@@ -94,10 +71,9 @@ function escapeFunctionBody(str) {
         stringAndCommentSpans.push([match.index, match.index + match[0].length]);
     }
 
-    // Both the script-close matches (found below, in source order via
-    // `replace`) and `stringAndCommentSpans` are ordered by offset, so a
-    // single forward-moving cursor is enough to classify every match in
-    // O(n) total instead of re-scanning every span for every match.
+    // Matches and spans are both in increasing offset order, so a single
+    // forward-moving cursor classifies every match in O(n) total instead of
+    // rescanning all spans for each match.
     var spanCursor = 0;
 
     str = str.replace(SCRIPT_CLOSE_REGEXP, function(scriptCloseMatch, offset) {
@@ -107,19 +83,14 @@ function escapeFunctionBody(str) {
         var span = stringAndCommentSpans[spanCursor];
         var inStringOrComment = !!span && offset >= span[0] && offset < span[1];
         if (!inStringOrComment) {
-            // Outside of strings/templates/comments, `<` and `/` are real
-            // JavaScript tokens (a comparison operator, a regex literal
-            // delimiter, division, etc.) and can't be rewritten as unicode
-            // escapes without producing invalid syntax. Inserting
-            // whitespace between them is a no-op for JavaScript semantics
-            // (tokens are whitespace-insensitive here) while still breaking
-            // up the literal `</script` sequence the HTML tokenizer looks
-            // for.
+            // In plain code, `<` and `/` may be real tokens (comparison,
+            // regex delimiter, division, ...), so they can't be rewritten
+            // as unicode escapes without breaking syntax. A space is a
+            // no-op here but still breaks up the `</script` sequence.
             return '< ' + scriptCloseMatch.slice(1);
         }
-        // Inside a string, template literal, or comment the exact
-        // characters matter (or, for comments, don't matter but must stay
-        // valid), so use character-preserving unicode escapes instead.
+        // Inside a string/template/regex/comment, characters must be
+        // preserved exactly, so unicode-escape instead.
         return scriptCloseMatch.replace(/</g, '\\u003C').replace(/\//g, '\\u002F').replace(/>/g, '\\u003E');
     });
     str = str.replace(/\u2028/g, '\\u2028');

--- a/index.js
+++ b/index.js
@@ -15,9 +15,23 @@ var IS_NATIVE_CODE_REGEXP = /\{\s*\[native code\]\s*\}/g;
 var IS_PURE_FUNCTION = /function.*?\(/;
 var IS_ARROW_FUNCTION = /.*?=>.*?/;
 var UNSAFE_CHARS_REGEXP   = /[<>\/\u2028\u2029]/g;
-// Regex to match </script> and variations (case-insensitive) for XSS protection
-// Matches </script followed by optional whitespace/attributes and >
+// Regexes to match script end tags (case-insensitive) for XSS protection.
+// The first matches a complete `</script...>` tag within a single value.
+// The second matches a bare `</script` prefix followed by one of the
+// characters (TAB, LF, FF, CR, SPACE, `/`, `>`) that the WHATWG HTML
+// tokenizer's "script data end tag name state" treats as ending the tag
+// name and starting tag recognition (see
+// https://html.spec.whatwg.org/multipage/parsing.html#script-data-end-tag-name-state).
+// Because that state only needs to see `</script` plus one such character to
+// commit to end-tag parsing, the matching closing `>` can be supplied by a
+// *different* serialized value later in the output; escaping the prefix on
+// its own closes that gap. A trailing backslash is also treated as a
+// boundary so that a literal `\t`/`\n`/etc. escape sequence emitted by
+// `Function.prototype.toString()` (backslash followed by a letter, not an
+// actual control character) is escaped too, even though a lone backslash is
+// not itself a WHATWG delimiter.
 var SCRIPT_CLOSE_REGEXP = /<\/script[^>]*>/gi;
+var SCRIPT_CLOSE_PREFIX_REGEXP = /<\/script(?=[\t\n\f\r \/>\\])/gi;
 
 var RESERVED_SYMBOLS = ['*', 'async'];
 
@@ -35,16 +49,16 @@ function escapeUnsafeChars(unsafeChar) {
     return ESCAPED_CHARS[unsafeChar];
 }
 
-// Escape function body for XSS protection while preserving arrow function syntax
+// Escape function body for XSS protection while preserving arrow function
+// syntax (=>) and comparison operators: only script end tags and line
+// terminators are escaped.
 function escapeFunctionBody(str) {
-    // Escape </script> sequences and variations (case-insensitive) - the main XSS risk
-    // Matches </script followed by optional whitespace/attributes and >
-    // This must be done first before other replacements
     str = str.replace(SCRIPT_CLOSE_REGEXP, function(match) {
-        // Escape all <, /, and > characters in the closing script tag
         return match.replace(/</g, '\\u003C').replace(/\//g, '\\u002F').replace(/>/g, '\\u003E');
     });
-    // Escape line terminators (these are always unsafe)
+    str = str.replace(SCRIPT_CLOSE_PREFIX_REGEXP, function(match) {
+        return match.replace(/</g, '\\u003C').replace(/\//g, '\\u002F');
+    });
     str = str.replace(/\u2028/g, '\\u2028');
     str = str.replace(/\u2029/g, '\\u2029');
     return str;
@@ -163,7 +177,6 @@ module.exports = function serialize(obj, options) {
       }
 
       // Escape unsafe HTML characters in function body for XSS protection
-      // This must preserve arrow function syntax (=>) while escaping </script>
       if (options && options.unsafe !== true) {
           serializedFn = escapeFunctionBody(serializedFn);
       }

--- a/index.js
+++ b/index.js
@@ -15,23 +15,28 @@ var IS_NATIVE_CODE_REGEXP = /\{\s*\[native code\]\s*\}/g;
 var IS_PURE_FUNCTION = /function.*?\(/;
 var IS_ARROW_FUNCTION = /.*?=>.*?/;
 var UNSAFE_CHARS_REGEXP   = /[<>\/\u2028\u2029]/g;
-// Regexes to match script end tags (case-insensitive) for XSS protection.
-// The first matches a complete `</script...>` tag within a single value.
-// The second matches a bare `</script` prefix followed by one of the
-// characters (TAB, LF, FF, CR, SPACE, `/`, `>`) that the WHATWG HTML
-// tokenizer's "script data end tag name state" treats as ending the tag
-// name and starting tag recognition (see
-// https://html.spec.whatwg.org/multipage/parsing.html#script-data-end-tag-name-state).
-// Because that state only needs to see `</script` plus one such character to
-// commit to end-tag parsing, the matching closing `>` can be supplied by a
-// *different* serialized value later in the output; escaping the prefix on
-// its own closes that gap. A trailing backslash is intentionally NOT
-// included: HTML tokenization happens before any JavaScript escape-sequence
-// processing, so a literal backslash character is not itself a delimiter
-// recognized by the tokenizer, and treating it as one would incorrectly
-// alter the raw text of tagged template literals (e.g. `String.raw`).
-var SCRIPT_CLOSE_REGEXP = /<\/script[^>]*>/gi;
-var SCRIPT_CLOSE_PREFIX_REGEXP = /<\/script(?=[\t\n\f\r \/>])/gi;
+// Matches a script end tag (case-insensitive) for XSS protection, in either
+// of two forms:
+//   1. `<\/script[^>]*>` - a complete `</script...>` tag within a single
+//      value, escaped in full (including the closing `>`).
+//   2. `<\/script(?=[\t\n\f\r \/>])` - a bare `</script` prefix followed by
+//      one of the characters (TAB, LF, FF, CR, SPACE, `/`, `>`) that the
+//      WHATWG HTML tokenizer's "script data end tag name state" treats as
+//      ending the tag name and starting end-tag recognition (see
+//      https://html.spec.whatwg.org/multipage/parsing.html#script-data-end-tag-name-state).
+//      Because that state only needs to see `</script` plus one such
+//      character to commit to end-tag parsing, the matching closing `>` can
+//      be supplied by a *different* serialized value later in the output, so
+//      the closing tag itself doesn't need to be present in the same match;
+//      escaping the prefix on its own closes that gap. A trailing backslash
+//      is intentionally NOT included: HTML tokenization happens before any
+//      JavaScript escape-sequence processing, so a literal backslash
+//      character is not itself a delimiter recognized by the tokenizer, and
+//      treating it as one would incorrectly alter the raw text of tagged
+//      template literals (e.g. `String.raw`).
+// The first alternative is tried first so a fully-formed tag (the common
+// case) is escaped as one unit, including its closing `>`.
+var SCRIPT_CLOSE_REGEXP = /<\/script[^>]*>|<\/script(?=[\t\n\f\r \/>])/gi;
 
 var RESERVED_SYMBOLS = ['*', 'async'];
 
@@ -49,15 +54,51 @@ function escapeUnsafeChars(unsafeChar) {
     return ESCAPED_CHARS[unsafeChar];
 }
 
+// Matches string literals, template literals, and comments so that
+// `escapeFunctionBody` can tell them apart from plain code (see below).
+// This is a lightweight heuristic, not a full parser: a whole template
+// literal (backtick to backtick) is treated as one opaque span, including
+// any `${...}` substitutions inside it. Known limitation: if a `</script`
+// sequence appears *inside* such a substitution (which is actual code, e.g.
+// `` `${ x</script/.test(x) }` ``), it will be misidentified as
+// string/template content and unicode-escaped, which can still produce a
+// SyntaxError. This is considered an acceptable trade-off for keeping this
+// scan simple; none of our tests hit this narrower case.
+var STRING_OR_COMMENT_REGEXP = /\/\*[\s\S]*?\*\/|\/\/[^\n]*|'(?:\\.|[^'\\])*'|"(?:\\.|[^"\\])*"|`(?:\\.|[^`\\])*`/g;
+
 // Escape function body for XSS protection while preserving arrow function
-// syntax (=>) and comparison operators: only script end tags and line
-// terminators are escaped.
+// syntax (=>), comparison operators, and regex literals: only script end
+// tags and line terminators are escaped.
 function escapeFunctionBody(str) {
-    str = str.replace(SCRIPT_CLOSE_REGEXP, function(match) {
-        return match.replace(/</g, '\\u003C').replace(/\//g, '\\u002F').replace(/>/g, '\\u003E');
-    });
-    str = str.replace(SCRIPT_CLOSE_PREFIX_REGEXP, function(match) {
-        return match.replace(/</g, '\\u003C').replace(/\//g, '\\u002F');
+    // Record the [start, end) span of every string literal, template
+    // literal, and comment so matches inside them can be treated
+    // differently from matches in plain code (see below).
+    var stringAndCommentSpans = [];
+    var match;
+    STRING_OR_COMMENT_REGEXP.lastIndex = 0;
+    while ((match = STRING_OR_COMMENT_REGEXP.exec(str))) {
+        stringAndCommentSpans.push([match.index, match.index + match[0].length]);
+    }
+
+    str = str.replace(SCRIPT_CLOSE_REGEXP, function(scriptCloseMatch, offset) {
+        var inStringOrComment = stringAndCommentSpans.some(function(span) {
+            return offset >= span[0] && offset < span[1];
+        });
+        if (!inStringOrComment) {
+            // Outside of strings/templates/comments, `<` and `/` are real
+            // JavaScript tokens (a comparison operator, a regex literal
+            // delimiter, division, etc.) and can't be rewritten as unicode
+            // escapes without producing invalid syntax. Inserting
+            // whitespace between them is a no-op for JavaScript semantics
+            // (tokens are whitespace-insensitive here) while still breaking
+            // up the literal `</script` sequence the HTML tokenizer looks
+            // for.
+            return '< ' + scriptCloseMatch.slice(1);
+        }
+        // Inside a string, template literal, or comment the exact
+        // characters matter (or, for comments, don't matter but must stay
+        // valid), so use character-preserving unicode escapes instead.
+        return scriptCloseMatch.replace(/</g, '\\u003C').replace(/\//g, '\\u002F').replace(/>/g, '\\u003E');
     });
     str = str.replace(/\u2028/g, '\\u2028');
     str = str.replace(/\u2029/g, '\\u2029');

--- a/index.js
+++ b/index.js
@@ -25,13 +25,13 @@ var UNSAFE_CHARS_REGEXP   = /[<>\/\u2028\u2029]/g;
 // Because that state only needs to see `</script` plus one such character to
 // commit to end-tag parsing, the matching closing `>` can be supplied by a
 // *different* serialized value later in the output; escaping the prefix on
-// its own closes that gap. A trailing backslash is also treated as a
-// boundary so that a literal `\t`/`\n`/etc. escape sequence emitted by
-// `Function.prototype.toString()` (backslash followed by a letter, not an
-// actual control character) is escaped too, even though a lone backslash is
-// not itself a WHATWG delimiter.
+// its own closes that gap. A trailing backslash is intentionally NOT
+// included: HTML tokenization happens before any JavaScript escape-sequence
+// processing, so a literal backslash character is not itself a delimiter
+// recognized by the tokenizer, and treating it as one would incorrectly
+// alter the raw text of tagged template literals (e.g. `String.raw`).
 var SCRIPT_CLOSE_REGEXP = /<\/script[^>]*>/gi;
-var SCRIPT_CLOSE_PREFIX_REGEXP = /<\/script(?=[\t\n\f\r \/>\\])/gi;
+var SCRIPT_CLOSE_PREFIX_REGEXP = /<\/script(?=[\t\n\f\r \/>])/gi;
 
 var RESERVED_SYMBOLS = ['*', 'async'];
 

--- a/test/unit/serialize.js
+++ b/test/unit/serialize.js
@@ -710,6 +710,22 @@ describe('serialize( obj )', function () {
             strictEqual(deserialized("'"), fn("'"));
             strictEqual(deserialized('x'), fn('x'));
         });
+
+        it('should not let a `/` inside a regex character class end the regex literal early', function () {
+            // `/` inside `[...]` doesn't need to be escaped and doesn't
+            // terminate the regex literal. If it were mistaken for the
+            // closing delimiter, the real string literal that follows would
+            // be misidentified and its `</script ` payload left unescaped.
+            function fn(x) { return /[/']/.test(x) ? '</script ' : 'ok'; }
+            var serialized = serialize(fn);
+
+            strictEqual(/<\/script[\t\n\f\r \/>]/i.test(serialized), false);
+
+            var deserialized; eval('deserialized = ' + serialized);
+            strictEqual(deserialized("'"), fn("'"));
+            strictEqual(deserialized('/'), fn('/'));
+            strictEqual(deserialized('x'), fn('x'));
+        });
     });
 
     describe('options', function () {

--- a/test/unit/serialize.js
+++ b/test/unit/serialize.js
@@ -696,6 +696,20 @@ describe('serialize( obj )', function () {
             strictEqual(deserialized('script'), fn('script'));
             strictEqual(deserialized('other'), fn('other'));
         });
+
+        it('should not let a quote inside a regex literal misalign a later string literal', function () {
+            // The quote in `/'/` must not be mistaken for the start of a
+            // string; otherwise the real string below is misidentified and
+            // its `</script ` payload is left unescaped as plain code.
+            function fn(x) { return /'/.test(x) ? '</script ' : 'ok'; }
+            var serialized = serialize(fn);
+
+            strictEqual(/<\/script[\t\n\f\r \/>]/i.test(serialized), false);
+
+            var deserialized; eval('deserialized = ' + serialized);
+            strictEqual(deserialized("'"), fn("'"));
+            strictEqual(deserialized('x'), fn('x'));
+        });
     });
 
     describe('options', function () {

--- a/test/unit/serialize.js
+++ b/test/unit/serialize.js
@@ -680,6 +680,22 @@ describe('serialize( obj )', function () {
             strictEqual(typeof deserialized.a, 'function');
             strictEqual(typeof deserialized.b, 'function');
         });
+
+        it('should not corrupt `<` used as a comparison operator followed by a regex literal', function () {
+            // `</script` here is not an HTML closing tag: it's the token
+            // sequence `<` (less-than) followed by the regex literal
+            // `/script/`. Naively unicode-escaping `<` and `/` in this
+            // context produces invalid JavaScript syntax.
+            function fn(x) { return x</script/.test(x); }
+            var serialized = serialize(fn);
+
+            var deserialized;
+            eval('deserialized = ' + serialized); // must not throw a SyntaxError
+            strictEqual(typeof deserialized, 'function');
+            // Behavior must be identical to the original function.
+            strictEqual(deserialized('script'), fn('script'));
+            strictEqual(deserialized('other'), fn('other'));
+        });
     });
 
     describe('options', function () {

--- a/test/unit/serialize.js
+++ b/test/unit/serialize.js
@@ -666,6 +666,20 @@ describe('serialize( obj )', function () {
             strictEqual(typeof deserialized, 'function');
             strictEqual(deserialized(), '</script\t>');
         });
+
+        it('should encode split script-closing payload across function bodies', function () {
+            var serialized = serialize({
+                a: function () { /* </script */ },
+                b: function () { /* > <img src=x onerror=alert(1)> */ }
+            });
+
+            strictEqual(serialized.includes('</script'), false);
+            strictEqual(serialized.includes('\\u003C\\u002Fscript'), true);
+
+            var deserialized; eval('deserialized = ' + serialized);
+            strictEqual(typeof deserialized.a, 'function');
+            strictEqual(typeof deserialized.b, 'function');
+        });
     });
 
     describe('options', function () {


### PR DESCRIPTION
## Summary

Fixes a variant of the XSS vulnerability reported in #220 that remained after the earlier fix (`738a8e9`).

## Problem

`escapeFunctionBody()` only escaped a complete `</script...>` tag when it appeared within a single serialized value. So the tag could be **split across two values** to bypass it:

```js
serialize({
  a: function(){ /* </script */ },                          // no closing '>'
  b: function(){ /* > <img src=x onerror=alert(1)> */ }     // supplies '>' and markup
});
```

Per the WHATWG HTML tokenizer's [script data end tag name state](https://html.spec.whatwg.org/multipage/parsing.html#script-data-end-tag-name-state), an HTML parser only needs `</script` followed by TAB/LF/FF/CR/SPACE/`/`/`>` to start parsing an end tag — it doesn't need the `>` in the same value.

## Fix

- `SCRIPT_CLOSE_REGEXP` now also matches a bare `</script` prefix followed by one of those delimiter characters, so it's escaped even without a closing `>` in the same value.
- Escaping is lexically aware: the function source is first scanned for string/template/regex literals and comments. Inside those, characters are unicode-escaped as before. In plain code, `<`/`/` may be real tokens (comparison, regex delimiter, division), so unicode-escaping them would break syntax — a space is inserted instead, which is a no-op for JS but still breaks up `</script`.
- Known limitation: a template literal is treated as one opaque span including any `${...}` inside it, so a `</script`-like sequence in a substitution (real code) can still be misclassified. Accepted trade-off to keep the scan simple.
- Span lookup uses a single forward cursor (O(n)) rather than a per-match scan, since matches and spans are both in increasing offset order.
